### PR TITLE
Add PHP 8.1 Support (Addresses implicit type errors)

### DIFF
--- a/src/Abstracts/AbstractFaceDetector.php
+++ b/src/Abstracts/AbstractFaceDetector.php
@@ -6,7 +6,7 @@ use Leomarriel\FaceDetector\Contracts\FaceDetectorContract;
 use Leomarriel\FaceDetector\Exceptions\NotFoundFaceException;
 
 abstract class AbstractFaceDetector implements FaceDetectorContract
-{   
+{
     /** @var string */
     private $reduced_canvas;
 
@@ -21,20 +21,20 @@ abstract class AbstractFaceDetector implements FaceDetectorContract
     * @return array|false
     */
     public function detector($target)
-    {    
-        $im_width = imagesx($target);
-        $im_height = imagesy($target);
+    {
+        $im_width = (int) imagesx($target);
+        $im_height = (int) imagesy($target);
 
         $diff_width = 320 - $im_width;
         $diff_height = 240 - $im_height;
         if ($diff_width > $diff_height) {
-            $ratio = $im_width / 320;
+            $ratio = (int) ($im_width / 320);
         } else {
-            $ratio = $im_height / 240;
+            $ratio = (int) ($im_height / 240);
         }
 
         if ($ratio != 0) {
-            $this->reduced_canvas = imagecreatetruecolor($im_width / $ratio, $im_height / $ratio);
+            $this->reduced_canvas = imagecreatetruecolor(intval($im_width / $ratio), intval($im_height / $ratio));
 
             imagecopyresampled(
                 $this->reduced_canvas,
@@ -43,8 +43,8 @@ abstract class AbstractFaceDetector implements FaceDetectorContract
                 0,
                 0,
                 0,
-                $im_width / $ratio,
-                $im_height / $ratio,
+                intval($im_width / $ratio),
+                intval($im_height / $ratio),
                 $im_width,
                 $im_height
             );
@@ -75,7 +75,7 @@ abstract class AbstractFaceDetector implements FaceDetectorContract
         }
 
         if($this->face && $this->face['w'] ?? 0 > 0) {
-            return $this->face; 
+            return $this->face;
         }
 
         if($this->settings['noFoundFaceException']) {
@@ -86,7 +86,7 @@ abstract class AbstractFaceDetector implements FaceDetectorContract
 
         return false;
     }
-    
+
     abstract protected function getImgStats($tmpFile);
 
     abstract protected function computeII($tmpFile, $image_width, $image_height);
@@ -94,5 +94,5 @@ abstract class AbstractFaceDetector implements FaceDetectorContract
     abstract protected function doDetectGreedyBigToSmall($ii, $ii2, $width, $height);
 
     abstract protected function detectOnSubImage($x, $y, $scale, $ii, $ii2, $w, $iiw, $inv_area);
-    
+
 }

--- a/src/Services/Detector.php
+++ b/src/Services/Detector.php
@@ -23,13 +23,13 @@ class Detector extends AbstractFaceDetector
     protected function initializeDefaults()
     {
         $this->libraryFile = base_path() . '/vendor/leomarriel/laravel-face-detector/src/Library/facedetector.dat';
-        
+
         if (!is_file($this->libraryFile)) {
             throw new NotValidLibraryException(
                 "This Library ({$this->libraryFile}) is not a valid."
             );
         }
-        
+
         $this->libraryFile = unserialize(file_get_contents($this->libraryFile));
     }
 
@@ -68,7 +68,7 @@ class Detector extends AbstractFaceDetector
                 $red = ($rgb >> 16) & 0xFF;
                 $green = ($rgb >> 8) & 0xFF;
                 $blue = $rgb & 0xFF;
-                $grey = (0.2989*$red + 0.587*$green + 0.114*$blue)>>0;
+                $grey = (int) (0.2989*$red + 0.587*$green + 0.114*$blue)>>0;
                 $rowsum += $grey;
                 $rowsum2 += $grey*$grey;
 
@@ -89,10 +89,10 @@ class Detector extends AbstractFaceDetector
         $start_scale = $s_h < $s_w ? $s_h : $s_w;
         $scale_update = 1 / 1.2;
         for ($scale = $start_scale; $scale > 1; $scale *= $scale_update) {
-            $w = (20*$scale) >> 0;
+            $w = (int) (20*$scale) >> 0;
             $endx = $width - $w - 1;
             $endy = $height - $w - 1;
-            $step = max($scale, 2) >> 0;
+            $step = (int) max($scale, 2) >> 0;
             $inv_area = 1 / ($w*$w);
             for ($y = 0; $y < $endy; $y += $step) {
                 for ($x = 0; $x < $endx; $x += $step) {
@@ -145,7 +145,7 @@ class Detector extends AbstractFaceDetector
                     $count_rects = count($rects);
 
                     for ($i_rect = 0; $i_rect < $count_rects; $i_rect++) {
-                        $s = $scale;
+                        $s = (int) $scale;
                         $rect = $rects[$i_rect];
                         $rx = ($rect[0]*$s+$x)>>0;
                         $ry = ($rect[1]*$s+$y)>>0;


### PR DESCRIPTION
What great timing... I just started looking for a Laravel package to do just this! Thanks for creating.

Hope you don't mind a PR to try and address the "implicit conversion from float" errors that appear on PHP 8.1 by adding explicit typecasting in some places.

See: https://stackoverflow.com/questions/71534654/implicit-conversion-from-float-number-to-int-loses-precision

Feedback welcome!